### PR TITLE
Set local directory when the 'use same address' switch is unchecked

### DIFF
--- a/app/src/main/java/nl/hnogames/domoticz/Utils/SharedPrefUtil.java
+++ b/app/src/main/java/nl/hnogames/domoticz/Utils/SharedPrefUtil.java
@@ -551,6 +551,7 @@ public class SharedPrefUtil {
         setDomoticzLocalPassword(getDomoticzRemotePassword());
         setDomoticzLocalUrl(getDomoticzRemoteUrl());
         setDomoticzLocalPort(getDomoticzRemotePort());
+        setDomoticzLocalDirectory(getDomoticzRemoteDirectory());
         setDomoticzLocalSecure(isDomoticzRemoteSecure());
         setDomoticzLocalAuthenticationMethod(getDomoticzRemoteAuthenticationMethod());
     }


### PR DESCRIPTION
I missed this when adding directory support. The local directory was not set when the use same address switch was unchecked.