### PR TITLE
Added support for the Evohome switch

### DIFF
--- a/app/src/main/java/nl/hnogames/domoticz/Domoticz/Domoticz.java
+++ b/app/src/main/java/nl/hnogames/domoticz/Domoticz/Domoticz.java
@@ -39,6 +39,7 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -244,6 +245,7 @@ public class Domoticz {
         switchesSupported.add(Device.Type.Name.DOORBELL);
         switchesSupported.add(Device.Type.Name.SECURITY);
         switchesSupported.add(Device.Type.Name.SELECTOR);
+        switchesSupported.add(Device.Type.Name.EVOHOME);
         return switchesSupported;
     }
 
@@ -514,6 +516,29 @@ public class Domoticz {
                 actionUrl = Url.Switch.COLOR;
                 break;
 
+            case Device.ModalSwitch.Action.AUTO:
+                actionUrl = Url.ModalAction.AUTO;
+                break;
+
+            case Device.ModalSwitch.Action.ECONOMY:
+                actionUrl = Url.ModalAction.ECONOMY;
+                break;
+
+            case Device.ModalSwitch.Action.AWAY:
+                actionUrl = Url.ModalAction.AWAY;
+                break;
+
+            case Device.ModalSwitch.Action.DAY_OFF:
+                actionUrl = Url.ModalAction.DAY_OFF;
+                break;
+
+            case Device.ModalSwitch.Action.CUSTOM:
+                actionUrl = Url.ModalAction.CUSTOM;
+                break;
+
+            case Device.ModalSwitch.Action.HEATING_OFF:
+                actionUrl = Url.ModalAction.HEATING_OFF;
+                break;
 
             default:
                 throw new NullPointerException(
@@ -533,6 +558,13 @@ public class Domoticz {
                 jsonUrl = url
                         + String.valueOf(idx)
                         + Url.Switch.CMD + actionUrl;
+                break;
+
+            case Json.Url.Set.MODAL_SWITCHES:
+                url = Url.ModalSwitch.GET;
+                jsonUrl = url
+                        + String.valueOf(idx)
+                        + Url.ModalSwitch.STATUS + actionUrl;
                 break;
 
             case Json.Url.Set.TEMP:
@@ -755,6 +787,22 @@ public class Domoticz {
             url = url.replace("&iswhite=false", "&iswhite=true");
 
         Log.v(TAG, "Action: " + url);
+        RequestUtil.makeJsonPutRequest(parser,
+                getUserCredentials(Authentication.USERNAME),
+                getUserCredentials(Authentication.PASSWORD),
+                url, mSessionUtil, true, 3);
+    }
+
+    public void setModalAction(int id,
+                               int status, // one of Domoticz.Device.ModalSwitch.Action
+                               int action, // behaves like this action == 1 ? 1 : 0
+                               Calendar until,
+                               setCommandReceiver receiver) {
+        String url = constructSetUrl(Domoticz.Json.Url.Set.MODAL_SWITCHES, id, status, 0);
+        url += "&action=" + action;
+
+        Log.v(TAG, "Action: " + url);
+        setCommandParser parser = new setCommandParser(receiver);
         RequestUtil.makeJsonPutRequest(parser,
                 getUserCredentials(Authentication.USERNAME),
                 getUserCredentials(Authentication.PASSWORD),
@@ -1081,6 +1129,8 @@ public class Domoticz {
         }
 
         switch (Type.toLowerCase()) {
+            case "heating":
+                return R.drawable.heating;
             case "thermostat":
                 return R.drawable.flame;
         }
@@ -1139,6 +1189,17 @@ public class Domoticz {
             }
         }
 
+        interface ModalSwitch {
+            interface Action {
+                int AUTO = 60;
+                int ECONOMY = 61;
+                int AWAY = 62;
+                int DAY_OFF = 63;
+                int CUSTOM = 64;
+                int HEATING_OFF = 65;
+            }
+        }
+
         interface Type {
             @SuppressWarnings("unused")
             interface Value {
@@ -1186,6 +1247,7 @@ public class Domoticz {
                 String TEMPHUMIDITYBARO = "Temp + Humidity + Baro";
                 String WIND = "Wind";
                 String SELECTOR = "Selector";
+                String EVOHOME = "evohome";
             }
         }
 
@@ -1194,12 +1256,14 @@ public class Domoticz {
             interface Value {
                 int RGB = 1;
                 int SECURITYPANEL = 2;
+                int EVOHOME = 3;
             }
 
             @SuppressWarnings("unused")
             interface Name {
                 String RGB = "RGB";
                 String SECURITYPANEL = "Security Panel";
+                String EVOHOME = "Evohome";
             }
         }
 
@@ -1254,6 +1318,7 @@ public class Domoticz {
                 int SCENEFAVORITE = 106;
                 int EVENT = 105;
                 int RGBCOLOR = 107;
+                int MODAL_SWITCHES = 108;
             }
         }
 
@@ -1320,6 +1385,15 @@ public class Domoticz {
             String MIN = "Min";
         }
 
+        interface ModalAction {
+            String AUTO = "Auto";
+            String ECONOMY = "AutoWithEco";
+            String AWAY = "Away";
+            String DAY_OFF = "DayOff";
+            String CUSTOM = "Custom";
+            String HEATING_OFF = "HeatingOff";
+        }
+
         @SuppressWarnings("SpellCheckingInspection")
         interface Category {
             String ALLDEVICES = "/json.htm?type=devices";
@@ -1346,6 +1420,11 @@ public class Domoticz {
             String GET = "/json.htm?type=command&param=switchlight&idx=";
             String CMD = "&switchcmd=";
             String LEVEL = "&level=";
+        }
+
+        interface ModalSwitch {
+            String GET = "/json.htm?type=command&param=switchmodal&idx=";
+            String STATUS = "&status=";
         }
 
         @SuppressWarnings("SpellCheckingInspection")

--- a/app/src/main/java/nl/hnogames/domoticz/Fragments/Switches.java
+++ b/app/src/main/java/nl/hnogames/domoticz/Fragments/Switches.java
@@ -22,8 +22,10 @@
 
 package nl.hnogames.domoticz.Fragments;
 
+import android.app.AlertDialog;
 import android.app.ProgressDialog;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.graphics.Color;
 import android.os.Parcelable;
 import android.support.design.widget.CoordinatorLayout;
@@ -35,9 +37,11 @@ import android.widget.AdapterView;
 import android.widget.ListView;
 import android.widget.Toast;
 
+import com.afollestad.materialdialogs.MaterialDialog;
 import com.nhaarman.listviewanimations.appearance.simple.AlphaInAnimationAdapter;
 
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.List;
 
 import nl.hnogames.domoticz.Adapters.SwitchesAdapter;
@@ -413,6 +417,40 @@ public class Switches extends DomoticzFragment implements DomoticzFragmentListen
                 getSwitchesData();//refresh
             }
         });
+    }
+
+    @Override
+    public void onStateButtonClick(final int idx, int itemsRes, final int[] stateIds) {
+        new MaterialDialog.Builder(getActivity())
+                .title(R.string.choose_status)
+                .items(itemsRes)
+                .itemsIds(stateIds)
+                .itemsCallback(new MaterialDialog.ListCallback() {
+                    @Override
+                    public void onSelection(MaterialDialog dialog, View view, int which, CharSequence text) {
+                        setState(idx, stateIds[which], null);
+                    }
+                })
+                .show();;
+    }
+
+    private void setState(final int idx, int state, Calendar until) {
+        mDomoticz.setModalAction(idx,
+                state,
+                1,
+                until,
+                new setCommandReceiver() {
+                    @Override
+                    public void onReceiveResult(String result) {
+                        Snackbar.make(coordinatorLayout, getContext().getString(R.string.state_set) + ": " + getSwitch(idx).getName(), Snackbar.LENGTH_SHORT).show();
+                        getSwitchesData(); //refresh
+                    }
+
+                    @Override
+                    public void onError(Exception error) {
+                        Snackbar.make(coordinatorLayout, getContext().getString(R.string.error_state), Snackbar.LENGTH_SHORT).show();
+                    }
+                });
     }
 
     private DevicesInfo getSwitch(int idx) {

--- a/app/src/main/java/nl/hnogames/domoticz/Interfaces/switchesClickListener.java
+++ b/app/src/main/java/nl/hnogames/domoticz/Interfaces/switchesClickListener.java
@@ -41,4 +41,6 @@ public interface switchesClickListener {
     void onThermostatClick(int idx);
 
     void onSecurityPanelButtonClick(int idx);
+
+    void onStateButtonClick(int idx, int itemsRes, int[] itemIds);
 }

--- a/app/src/main/res/layout/switch_row_modal.xml
+++ b/app/src/main/res/layout/switch_row_modal.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@color/material_grey_300_"
+    android:paddingLeft="@dimen/row_space"
+    android:paddingRight="@dimen/row_space">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@drawable/bordershadow"
+        android:foreground="?android:attr/selectableItemBackground"
+        android:longClickable="true"
+        android:minHeight="?android:attr/listPreferredItemHeight"
+        android:orientation="horizontal"
+        android:paddingEnd="?android:attr/listPreferredItemPaddingEnd"
+        android:paddingLeft="?android:attr/listPreferredItemPaddingLeft"
+        android:paddingRight="?android:attr/listPreferredItemPaddingRight"
+        android:paddingStart="?android:attr/listPreferredItemPaddingStart">
+
+        <ImageView
+            android:id="@+id/rowIcon"
+            android:layout_width="40dp"
+            android:layout_height="40dp"
+            android:layout_gravity="center_vertical"
+            android:paddingRight="5dp"
+            android:src="@drawable/clock48" />
+
+        <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <RelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+
+                <TextView
+                    android:id="@+id/switch_name"
+                    style="@style/row_name"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_alignParentTop="true"
+                    tools:text="Switch name" />
+
+                <TextView
+                    android:id="@+id/switch_battery_level"
+                    style="@style/row_body1"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_alignParentLeft="true"
+                    android:layout_alignParentStart="true"
+                    android:layout_below="@+id/switch_name"
+                    android:text="@string/battery_level" />
+
+                <TextView
+                    android:id="@+id/switch_signal_level"
+                    style="@style/row_body2"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_below="@id/switch_battery_level"
+                    android:text="@string/signal_level" />
+
+                <Button
+                    android:id="@+id/set_status_button"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_alignParentRight="true"
+                    android:layout_centerVertical="true"
+                    android:background="@drawable/button"
+                    android:text="@string/set_temperature" />
+            </RelativeLayout>
+
+            <LinearLayout
+                android:id="@+id/extra_panel_button"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:paddingBottom="10dp"
+                android:paddingLeft="10dp">
+
+                <Button
+                    android:id="@+id/log_button"
+                    android:layout_width="wrap_content"
+                    android:layout_height="25dp"
+                    android:background="@drawable/button_status"
+                    android:text="@string/button_status_log" />
+
+                <Button
+                    android:id="@+id/timer_button"
+                    android:layout_width="wrap_content"
+                    android:layout_height="25dp"
+                    android:layout_marginLeft="10dp"
+                    android:background="@drawable/button_status"
+                    android:text="@string/button_status_timer" />
+            </LinearLayout>
+        </LinearLayout>
+    </LinearLayout>
+</LinearLayout>

--- a/app/src/main/res/layout/switch_row_modal_small.xml
+++ b/app/src/main/res/layout/switch_row_modal_small.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@color/material_grey_300_"
+    android:paddingLeft="@dimen/row_space"
+    android:paddingRight="@dimen/row_space">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@drawable/bordershadow"
+        android:foreground="?android:attr/selectableItemBackground"
+        android:longClickable="true"
+        android:minHeight="80dp"
+        android:orientation="horizontal"
+        android:paddingEnd="?android:attr/listPreferredItemPaddingEnd"
+        android:paddingLeft="?android:attr/listPreferredItemPaddingLeft"
+        android:paddingRight="?android:attr/listPreferredItemPaddingRight"
+        android:paddingStart="?android:attr/listPreferredItemPaddingStart">
+
+        <ImageView
+            android:id="@+id/rowIcon"
+            android:layout_width="40dp"
+            android:layout_height="40dp"
+            android:layout_gravity="center_vertical"
+            android:paddingRight="5dp"
+            android:src="@drawable/clock48" />
+
+        <RelativeLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <TextView
+                android:id="@+id/switch_name"
+                style="@style/row_name"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentTop="true"
+                tools:text="Switch name" />
+
+            <TextView
+                android:id="@+id/switch_battery_level"
+                style="@style/row_body1"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentLeft="true"
+                android:layout_alignParentStart="true"
+                android:layout_below="@+id/switch_name"
+                android:text="@string/battery_level" />
+
+            <TextView
+                android:id="@+id/switch_signal_level"
+                style="@style/row_body2"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_below="@id/switch_battery_level"
+                android:text="@string/signal_level" />
+
+            <Button
+                android:id="@+id/set_status_button"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentRight="true"
+                android:layout_centerVertical="true"
+                android:background="@drawable/button"
+                android:text="@string/set_temperature" />
+        </RelativeLayout>
+    </LinearLayout>
+</LinearLayout>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -28,6 +28,12 @@
   <string name="action_success">Vorgang erfolgreich</string>
   <string name="action_failed">Vorgang gescheitert</string>
   <string name="action_unknown">-Ergebnis der Aktion unbekannt</string>
+  <string name="normal">Normal</string>
+  <string name="economy">Economy</string>
+  <string name="away">Abwesend</string>
+  <string name="day_off">Ausnahmetag</string>
+  <string name="custom">Sonderprogramm</string>
+  <string name="heating_off">Heizung aus</string>
   <string name="debug_textview_title">Debuginformationen</string>
   <string name="msg_copiedToClipboard">Text in Zwischenablage kopiert</string>
   <string name="favorite">Favorit</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -28,6 +28,12 @@
   <string name="action_success">Acción exitosa</string>
   <string name="action_failed">Acción fallida</string>
   <string name="action_unknown">Resultado de la acción desconocida</string>
+  <string name="normal">Normal</string>
+  <string name="economy">Economía</string>
+  <string name="away">Salir</string>
+  <string name="day_off">Día festivo</string>
+  <string name="custom">Personal</string>
+  <string name="heating_off">Calef.apagada</string>
   <string name="debug_textview_title">Información de depuración</string>
   <string name="msg_copiedToClipboard">Texto copiado al portapapeles</string>
   <string name="favorite">Favorito</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -28,6 +28,12 @@
   <string name="action_success">Action succes</string>
   <string name="action_failed">Action échec</string>
   <string name="action_unknown">Action resultat inconnu</string>
+  <string name="normal">Normal</string>
+  <string name="economy">Économie</string>
+  <string name="away">Innocupé</string>
+  <string name="day_off">Jour de congé</string>
+  <string name="custom">Personnalisé</string>
+  <string name="heating_off">Chauffage arrêté</string>
   <string name="debug_textview_title">Debuggage info</string>
   <string name="msg_copiedToClipboard">Texte copié dans le presse papier</string>
   <string name="favorite">Favoris</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -28,6 +28,12 @@
   <string name="action_success">Sikeres művelet</string>
   <string name="action_failed">Sikertelen művelet</string>
   <string name="action_unknown">A művelet eredménye nem ismert</string>
+  <string name="normal">Normál</string>
+  <string name="economy">Takarékos</string>
+  <string name="away">Távollét</string>
+  <string name="day_off">Szabadnap</string>
+  <string name="custom">Egyéni</string>
+  <string name="heating_off">Fütés kikapcsolása</string>
   <string name="debug_textview_title">Hibakeresési információ</string>
   <string name="msg_copiedToClipboard">Szöveg a vágólapra másolva</string>
   <string name="favorite">Kedvenc</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -28,6 +28,13 @@
   <string name="action_success">Actie succesvol</string>
   <string name="action_failed">Actie mislukt</string>
   <string name="action_unknown">Actie resultaat onbekend</string>
+  <string name="choose_status">Status kiezen</string>
+  <string name="normal">Auto</string>
+  <string name="eco">Besparing - eco</string>
+  <string name="away">Afwezig</string>
+  <string name="day_off">Vrije dag</string>
+  <string name="custom">Custom</string>
+  <string name="heating_off">Verwarming uit</string>
   <string name="debug_textview_title">Debugging info</string>
   <string name="msg_copiedToClipboard">Tekst gekopieerd naar klembord</string>
   <string name="favorite">Favoriet</string>

--- a/app/src/main/res/values-nl/strings_switches.xml
+++ b/app/src/main/res/values-nl/strings_switches.xml
@@ -7,9 +7,11 @@
   <string name="idx_valuePlaceholder">33</string>
   <string name="placeholder_value">255</string>
   <string name="color_set">Kleur ingesteld voor</string>
+  <string name="state_set">Staat ingesteld voor</string>
   <string name="error_favorite">Kon favoriete niet instellen</string>
   <string name="error_logs">Het lukte niet om de logs op te halen</string>
   <string name="error_color">De kleur kon niet gewijzigd worden</string>
+  <string name="error_state">De staat kon niet gewijzigd worden</string>
   <string name="error_timer">De timers konden niet opgehaald worden</string>
   <string name="error_level">Level instellen voor schakelaar </string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -28,6 +28,12 @@
   <string name="action_success">Akcja zakończona skucesem</string>
   <string name="action_failed">Akcja nie powiodła się</string>
   <string name="action_unknown">Nieznany rezultat akcji</string>
+  <string name="normal">Normalny</string>
+  <string name="economy">Tryb ekonomiczny</string>
+  <string name="away">Wyjście</string>
+  <string name="day_off">Dzień wolny</string>
+  <string name="custom">Tryb niestandardowy</string>
+  <string name="heating_off">Ogrzewanie wyłączone</string>
   <string name="debug_textview_title">Informacje debugowania</string>
   <string name="msg_copiedToClipboard">Tekst skopiowany do schowka</string>
   <string name="favorite">Ulubione</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -29,6 +29,12 @@
   <string name="action_failed">Операция не выполнена</string>
   <string name="action_unknown">Результат действия неизвестен</string>
   <string name="debug_textview_title">Отладочная информация</string>
+  <string name="normal">Normal</string>
+  <string name="economy">Economy</string>
+  <string name="away">Away</string>
+  <string name="day_off">Day off</string>
+  <string name="custom">Custom</string>
+  <string name="heating_off">Heating off</string>
   <string name="msg_copiedToClipboard">Текст скопирован в буфер обмена</string>
   <string name="favorite">Избранное</string>
   <string name="yes">Да</string>

--- a/app/src/main/res/values/evohome_states.xml
+++ b/app/src/main/res/values/evohome_states.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools">
+
+    <string-array name="evohome_states" translatable="false">
+        <item>Auto</item>
+        <item>AutoWithEco</item>
+        <item>Away</item>
+        <item>DayOff</item>
+        <item>Custom</item>
+        <item>HeatingOff</item>
+    </string-array>
+
+    <string-array name="evohome_state_names" translatable="false">
+        <item>@string/normal</item>
+        <item>@string/eco</item>
+        <item>@string/away</item>
+        <item>@string/day_off</item>
+        <item>@string/custom</item>
+        <item>@string/heating_off</item>
+    </string-array>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -34,6 +34,14 @@
     <string name="action_failed">Action failed</string>
     <string name="action_unknown">Action result unknown</string>
 
+    <string name="choose_status">Choose state</string>
+    <string name="normal">Normal</string>
+    <string name="economy">Economy</string>
+    <string name="away">Away</string>
+    <string name="day_off">Day off</string>
+    <string name="custom">Custom</string>
+    <string name="heating_off">Heating off</string>
+
     <string name="debug_textview_title">Debugging info</string>
 
     <string name="msg_copiedToClipboard">Text copied to clipboard</string>

--- a/app/src/main/res/values/strings_switches.xml
+++ b/app/src/main/res/values/strings_switches.xml
@@ -9,9 +9,12 @@
 
     <string name="color_set">Color set for</string>
 
+    <string name="state_set">State set for</string>
+
     <string name="error_favorite">Could not set favorite</string>
     <string name="error_logs">Could not find any logs to show</string>
     <string name="error_color">Could not change the color</string>
+    <string name="error_state">Could not change the state</string>
     <string name="error_timer">Could not show the timers</string>
     <string name="error_level">Setting level for switch</string>
     <string name="set_level_switch">"Setting level for switch: %1$s to %2$d"</string>


### PR DESCRIPTION
This patch adds support for the Evohome switch. Switching modes works, although Domoticz itself cannot correctly set the mode to 'Day off' 'Custom' of 'Heating off'.

Translations are copied verbatim from the original Honeywell Comfort app and should be correct.

One thing I can't seem to fix is that the item is too high on the dashboard fragment.

![device-2016-01-12-222938](https://cloud.githubusercontent.com/assets/804104/12277652/c9454b38-b97c-11e5-8be2-d358cfc63295.png)
![device-2016-01-12-223013](https://cloud.githubusercontent.com/assets/804104/12277653/c94711c0-b97c-11e5-989f-1921708e3d39.png)
![screenshot_2016-01-12-22-39-04](https://cloud.githubusercontent.com/assets/804104/12277772/86b859ee-b97d-11e5-8b77-9a5c7d3c40b7.png)

