### PR TITLE
Fix notification subject and body. Use new additions inserted in domo…

### DIFF
--- a/app/src/main/java/nl/hnogames/domoticz/Utils/NotificationUtil.java
+++ b/app/src/main/java/nl/hnogames/domoticz/Utils/NotificationUtil.java
@@ -71,6 +71,7 @@ public class NotificationUtil {
                                 .setLargeIcon(BitmapFactory.decodeResource(context.getResources(), R.drawable.ic_launcher))
                                 .setContentTitle(alarmNot != null && alarmNot.contains(text) ? context.getString(R.string.alarm) + ": " + title : title)
                                 .setContentText(alarmNot != null && alarmNot.contains(text) ? context.getString(R.string.alarm) + ": " + text : text)
+								.setStyle(new NotificationCompat.BigTextStyle().bigText(text))
                                 .setGroupSummary(true)
                                 .setGroup(GROUP_KEY_NOTIFICATIONS)
                                 .setAutoCancel(true);

--- a/app/src/main/java/nl/hnogames/domoticz/app/AppController.java
+++ b/app/src/main/java/nl/hnogames/domoticz/app/AppController.java
@@ -148,13 +148,19 @@ public class AppController extends MultiDexApplication implements GcmListener {
     @Override
     public void onMessage(String s, Bundle bundle) {
         if (bundle.containsKey("message")) {
-            String message = bundle.getString("message");
-            try {
-                message = URLDecoder.decode(message, "UTF-8");
-            } catch (UnsupportedEncodingException e) {
-                e.printStackTrace();
+
+            String message = decode(bundle.getString("message"));
+
+            String subject = decode(bundle.getString("subject"));
+            if (subject != null) {
+                String body = decode(bundle.getString("body"));
+                //String priority = decode(bundle.getString("priority"));
+                //String extradata = decode(bundle.getString("extradata"));
+                //String deviceid = decode(bundle.getString("deviceid"));
+                NotificationUtil.sendSimpleNotification(subject, body, this);
+            } else {
+                NotificationUtil.sendSimpleNotification(this.getString(R.string.app_name_domoticz), message, this);
             }
-            NotificationUtil.sendSimpleNotification(this.getString(R.string.app_name_domoticz), message, this);
         }
     }
 
@@ -209,4 +215,16 @@ public class AppController extends MultiDexApplication implements GcmListener {
             }
         });
     }
+
+    private String decode(String str) {
+        if (str != null) {
+            try {
+                return URLDecoder.decode(str, "UTF-8");
+            } catch (UnsupportedEncodingException e) {
+                e.printStackTrace();
+            }
+        }
+        return str;
+    }
+
 }


### PR DESCRIPTION
…ticz.

Hi galadril, 
I changed domoticz to add all the available data in the notification using google cloud messaging.
[https://github.com/domoticz/domoticz/commit/61daee007d7509d2a8d1604a7b02aa37b3e76c9f](url)
This pull request keep the previous behavior for non beta user and add a new in case data are present.

I added a comment for all the available data if you want to react on it:
Device ID = the device that sent originally the notification, you can change the ico accordingly if you want
Subject and text
Priority = notification priority that you can react on to change the color of the notification for example
Extradata = data that can be sent (free text)

I changed also the notification to be able to see the complete text without the ... in case the notification is very long.

Best regards,
U.