### PR TITLE
Update SwitchDialog.java

### DIFF
--- a/app/src/main/java/nl/hnogames/domoticz/UI/SwitchDialog.java
+++ b/app/src/main/java/nl/hnogames/domoticz/UI/SwitchDialog.java
@@ -91,38 +91,27 @@ public class SwitchDialog implements DialogInterface.OnDismissListener {
         listView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
             @Override
             public void onItemClick(AdapterView<?> parent, View view, final int position, long id) {
-                if (info.get(position).isSceneOrGroup()) {
-                    if (dismissListener != null)
-                        dismissListener.onDismiss(info.get(position).getIdx(), null, info.get(position).getName(), info.get(position).isSceneOrGroup());
-                } else
-                mDomoticz.getStatus(info.get(position).getIdx(), new StatusReceiver() {
+            if (!info.get(position).isProtected()) {
+                if (dismissListener != null)
+                    dismissListener.onDismiss(info.get(position).getIdx(), null, info.get(position).getName(), info.get(position).isSceneOrGroup());
+            }
+            else {
+                PasswordDialog passwordDialog = new PasswordDialog(mContext, mDomoticz);
+                passwordDialog.show();
+                passwordDialog.onDismissListener(new PasswordDialog.DismissListener() {
                     @Override
-                    public void onReceiveStatus(ExtendedStatusInfo extendedStatusInfo) {
-                        if (!extendedStatusInfo.isProtected()) {
-                            if (dismissListener != null)
-                                dismissListener.onDismiss(info.get(position).getIdx(), null, info.get(position).getName(), info.get(position).isSceneOrGroup());
-                        } else {
-                            PasswordDialog passwordDialog = new PasswordDialog(mContext, mDomoticz);
-                            passwordDialog.show();
-                            passwordDialog.onDismissListener(new PasswordDialog.DismissListener() {
-                                @Override
-                                public void onDismiss(String password) {
-                                    dismissListener.onDismiss(info.get(position).getIdx(), password, info.get(position).getName(), info.get(position).isSceneOrGroup());
-                                }
-
-                                @Override
-                                public void onCancel() {
-                                }
-                            });
-                        }
+                    public void onDismiss(String password) {
+                        if (dismissListener != null)
+                            dismissListener.onDismiss(info.get(position).getIdx(), password, info.get(position).getName(), info.get(position).isSceneOrGroup());
                     }
 
                     @Override
-                    public void onError(Exception error) {
+                    public void onCancel() {
                     }
                 });
-
-                md.dismiss();
+            }
+            
+            md.dismiss();
             }
         });
 

--- a/app/src/main/java/nl/hnogames/domoticz/UI/SwitchDialog.java
+++ b/app/src/main/java/nl/hnogames/domoticz/UI/SwitchDialog.java
@@ -91,6 +91,10 @@ public class SwitchDialog implements DialogInterface.OnDismissListener {
         listView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
             @Override
             public void onItemClick(AdapterView<?> parent, View view, final int position, long id) {
+                if (info.get(position).isSceneOrGroup()) {
+                    if (dismissListener != null)
+                        dismissListener.onDismiss(info.get(position).getIdx(), null, info.get(position).getName(), info.get(position).isSceneOrGroup());
+                } else
                 mDomoticz.getStatus(info.get(position).getIdx(), new StatusReceiver() {
                     @Override
                     public void onReceiveStatus(ExtendedStatusInfo extendedStatusInfo) {

--- a/app/src/main/java/nl/hnogames/domoticz/UI/SwitchDialog.java
+++ b/app/src/main/java/nl/hnogames/domoticz/UI/SwitchDialog.java
@@ -91,27 +91,27 @@ public class SwitchDialog implements DialogInterface.OnDismissListener {
         listView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
             @Override
             public void onItemClick(AdapterView<?> parent, View view, final int position, long id) {
-            if (!info.get(position).isProtected()) {
-                if (dismissListener != null)
-                    dismissListener.onDismiss(info.get(position).getIdx(), null, info.get(position).getName(), info.get(position).isSceneOrGroup());
-            }
-            else {
-                PasswordDialog passwordDialog = new PasswordDialog(mContext, mDomoticz);
-                passwordDialog.show();
-                passwordDialog.onDismissListener(new PasswordDialog.DismissListener() {
-                    @Override
-                    public void onDismiss(String password) {
-                        if (dismissListener != null)
-                            dismissListener.onDismiss(info.get(position).getIdx(), password, info.get(position).getName(), info.get(position).isSceneOrGroup());
-                    }
+                if (!info.get(position).isProtected()) {
+                    if (dismissListener != null)
+                        dismissListener.onDismiss(info.get(position).getIdx(), null, info.get(position).getName(), info.get(position).isSceneOrGroup());
+                }
+                else {
+                    PasswordDialog passwordDialog = new PasswordDialog(mContext, mDomoticz);
+                    passwordDialog.show();
+                    passwordDialog.onDismissListener(new PasswordDialog.DismissListener() {
+                        @Override
+                        public void onDismiss(String password) {
+                            if (dismissListener != null)
+                                dismissListener.onDismiss(info.get(position).getIdx(), password, info.get(position).getName(), info.get(position).isSceneOrGroup());
+                        }
 
-                    @Override
-                    public void onCancel() {
-                    }
-                });
-            }
+                        @Override
+                        public void onCancel() {
+                        }
+                    });
+                }
             
-            md.dismiss();
+                md.dismiss();
             }
         });
 


### PR DESCRIPTION
If this is a scene, ExtendedStatusInformation is not available, and the getStatus call will fail. This renders scenes with a number where no switch with that same number is available, unselectable.
The solution is to skip the getstatus call.
But this uncovers the next problem. Scenes can be protected as well, so we need to check that via a getstatus call for scenes. But that doesn't exist yet. I can work on that one.

You can pull this change, and then at least nonprotected scenes can be selected in the 4 lists (geo/nfc/..).
I have Android Studio up and running, so I have tested this in emulator. 
I can start adding the getstatus for scenes as well, but that will take some time.