### PR TITLE
* Fixed editing a GeoFence point adds a new one

### DIFF
--- a/app/src/main/java/nl/hnogames/domoticz/Adapters/CamerasAdapter.java
+++ b/app/src/main/java/nl/hnogames/domoticz/Adapters/CamerasAdapter.java
@@ -31,6 +31,7 @@ import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.TextView;
 
+import com.squareup.picasso.MemoryPolicy;
 import com.squareup.picasso.Picasso;
 
 import java.util.ArrayList;
@@ -133,10 +134,18 @@ public class CamerasAdapter extends RecyclerView.Adapter<CamerasAdapter.DataObje
             String text = mContext.getResources().getQuantityString(R.plurals.devices, numberOfDevices, numberOfDevices);
             holder.name.setText(name);
 
-            picasso.load(imageUrl)
-                .placeholder(R.drawable.placeholder)
-                //.error(mSharedPrefs.darkThemeEnabled() ? R.drawable.baseline_error_outline_white_24 : R.drawable.baseline_error_outline_black_24)
-                .into(holder.camera);
+            if(holder.camera.getDrawable() == null) {
+                picasso.load(imageUrl)
+                        .placeholder(R.drawable.placeholder)
+                        //.error(mSharedPrefs.darkThemeEnabled() ? R.drawable.baseline_error_outline_white_24 : R.drawable.baseline_error_outline_black_24)
+                        .into(holder.camera);
+            }else
+                picasso.load(imageUrl)
+                    .memoryPolicy(MemoryPolicy.NO_CACHE)
+                        .noFade()
+                        .noPlaceholder()
+                    //.error(mSharedPrefs.darkThemeEnabled() ? R.drawable.baseline_error_outline_white_24 : R.drawable.baseline_error_outline_black_24)
+                    .into(holder.camera);
         }
     }
 

--- a/app/src/main/java/nl/hnogames/domoticz/GeoSettingsActivity.java
+++ b/app/src/main/java/nl/hnogames/domoticz/GeoSettingsActivity.java
@@ -417,7 +417,8 @@ public class GeoSettingsActivity extends AppCompatAssistActivity implements OnPe
             } else
                 showRadiusEditor(editedLocationID, name, latLng);
         } else
-            permissionHelper.onActivityForResult(requestCode);
+            if(resultCode != RESULT_CANCELED)
+                permissionHelper.onActivityForResult(requestCode);
     }
 
     private void showRadiusEditor(final int editedLocationID, String name, LatLng latlng)
@@ -464,12 +465,12 @@ public class GeoSettingsActivity extends AppCompatAssistActivity implements OnPe
                                 }
                         }else {
                             mSharedPrefs.addLocation(finalLocation);
-                            locations = mSharedPrefs.getLocations();
+                            locations.add(finalLocation);
 
                             GeoUtils.geofencesAlreadyRegistered = false;
                             oGeoUtils.AddGeofences();
 
-                            createListView();
+                            adapter.notifyDataSetChanged();
                         }
                     }
                 }).show();

--- a/app/src/main/java/nl/hnogames/domoticz/MainActivity.java
+++ b/app/src/main/java/nl/hnogames/domoticz/MainActivity.java
@@ -742,6 +742,7 @@ public class MainActivity extends AppCompatPermissionsActivity implements Digitu
                 .withIcon(R.mipmap.ic_launcher);
         if (mSharedPrefs.darkThemeEnabled()) {
             loggedinAccount.withSelectedColorRes(R.color.primary);
+            loggedinAccount.withSelectedTextColorRes(R.color.white);
         }
         allUsers.add(domoticz.getUserCredentials(Domoticz.Authentication.USERNAME));
 
@@ -920,6 +921,8 @@ public class MainActivity extends AppCompatPermissionsActivity implements Digitu
         if (mSharedPrefs.darkThemeEnabled()) {
             item.withIconColorRes(R.color.white);
             item.withSelectedColorRes(R.color.primary);
+            item.withSelectedTextColorRes(R.color.white);
+            item.withSelectedIconColorRes(R.color.white);
         }
         return item;
     }
@@ -932,6 +935,8 @@ public class MainActivity extends AppCompatPermissionsActivity implements Digitu
         if (mSharedPrefs.darkThemeEnabled()) {
             item.withIconColorRes(R.color.white);
             item.withSelectedColorRes(R.color.primary);
+            item.withSelectedTextColorRes(R.color.white);
+            item.withSelectedIconColorRes(R.color.white);
         }
         return item;
     }


### PR DESCRIPTION
When I clicked on a GeoFence point I and edited the data, it got added to the list as a new value.
I thought that it should update the current geofence item, as there is already an ,,*Add*" button for it.
Also saw in the code that the function exists only it just loads the previous position.
If this was a function for copy, maybe we should add an option to the long-press menu to copy the GeoFence info, and we could keep this edit function.

Update: The last commit should fix 2 bugs. I don't know if it should be in a different pull request, or if you accept any PRs anyway.
The last commit:
* Fixes that the cameras weren't updating because they got a cached image
* Fixes that on the navigation drawer the text color on the selected item was the same as it's background in dark mode. (Also aplies to secondary items and for the current account, on the account switcher)