### PR TITLE
Update domoticz API calls

### DIFF
--- a/domoticzapi/src/main/java/nl/hnogames/domoticzapi/DomoticzValues.java
+++ b/domoticzapi/src/main/java/nl/hnogames/domoticzapi/DomoticzValues.java
@@ -402,24 +402,24 @@ public class DomoticzValues {
 
         @SuppressWarnings("SpellCheckingInspection")
         interface Category {
-            String ALLDEVICES = "/json.htm?type=devices";
-            String DEVICES = "/json.htm?type=devices&filter=all&used=true";
-            String FAVORITES = "/json.htm?type=devices&filter=all&used=true&favorite=1";
+            String ALLDEVICES = "/json.htm?type=command&param=getdevices";
+            String DEVICES = "/json.htm?type=command&param=getdevices&filter=all&used=true";
+            String FAVORITES = "/json.htm?typecommand&param=get=devices&filter=all&used=true&favorite=1";
             String VERSION = "/json.htm?type=command&param=getversion";
             String DASHBOARD = ALLDEVICES + "&filter=all";
-            String SCENES = "/json.htm?type=scenes";
+            String SCENES = "/json.htm?type=command&param=getscenes";
             String SWITCHES = "/json.htm?type=command&param=getlightswitches";
             String WEATHER = ALLDEVICES + "&filter=weather&used=true";
-            String CAMERAS = "/json.htm?type=cameras";
+            String CAMERAS = "/json.htm?type=command&param=getcameras";
             String CAMERA = "/camsnapshot.jpg?idx=";
             String UTILITIES = ALLDEVICES + "&filter=utility&used=true";
-            String PLANS = "/json.htm?type=plans";
+            String PLANS = "/json.htm?type=command&param=getplans";
             String TEMPERATURE = ALLDEVICES + "&filter=temp&used=true";
-            String SWITCHLOG = "/json.htm?type=lightlog&idx=";
-            String TEXTLOG = "/json.htm?type=textlog&idx=";
-            String SCENELOG = "/json.htm?type=scenelog&idx=";
-            String SWITCHTIMER = "/json.htm?type=timers&idx=";
-            String SCENETIMER = "/json.htm?type=scenetimers&idx=";
+            String SWITCHLOG = "/json.htm?type=command&param=getlightlog&idx=";
+            String TEXTLOG = "/json.htm?type=command&param=gettextlog&idx=";
+            String SCENELOG = "/json.htm?type=command&param=getscenelog&idx=";
+            String SWITCHTIMER = "/json.htm?type=command&param=gettimers&idx=";
+            String SCENETIMER = "/json.htm?type=command&param=getscenetimers&idx=";
         }
 
         @SuppressWarnings({"SpellCheckingInspection", "unused"})
@@ -448,7 +448,7 @@ public class DomoticzValues {
         interface Temp {
             String GET = "/json.htm?type=command&param=udevice&idx=";
             String VALUE = "&nvalue=0&svalue=";
-            String GRAPH = "/json.htm?type=graph&sensor=temp&idx=";
+            String GRAPH = "/json.htm?type=command&param=getgraph&sensor=temp&idx=";
         }
 
         @SuppressWarnings("SpellCheckingInspection")
@@ -465,8 +465,8 @@ public class DomoticzValues {
 
         @SuppressWarnings("SpellCheckingInspection")
         interface Device {
-            String STATUS = "/json.htm?type=devices&rid=";
-            String SET_USED = "/json.htm?type=setused&idx=";
+            String STATUS = "/json.htm?type=command&param=getdevices&rid=";
+            String SET_USED = "/json.htm?type=command&param=getsetused&idx=";
         }
 
         @SuppressWarnings("unused")
@@ -476,13 +476,13 @@ public class DomoticzValues {
 
         @SuppressWarnings({"unused", "SpellCheckingInspection"})
         interface Plan {
-            String GET = "/json.htm?type=plans";
+            String GET = "/json.htm?type=command&param=getplans";
             String DEVICES = "/json.htm?type=command&param=getplandevices&idx=";
         }
 
         @SuppressWarnings({"unused", "SpellCheckingInspection"})
         interface Log {
-            String GRAPH = "/json.htm?type=graph&idx=";
+            String GRAPH = "/json.htm?type=command&param=getgraph&idx=";
             String GRAPH_RANGE = "&range=";
             String GRAPH_TYPE = "&sensor=";
 
@@ -492,7 +492,7 @@ public class DomoticzValues {
 
         @SuppressWarnings({"unused", "SpellCheckingInspection"})
         interface Notification {
-            String NOTIFICATION = "/json.htm?type=notifications&idx=";
+            String NOTIFICATION = "/json.htm?type=command&param=getnotifications&idx=";
         }
 
         @SuppressWarnings({"unused", "SpellCheckingInspection"})
@@ -512,13 +512,13 @@ public class DomoticzValues {
             String SUNRISE = "/json.htm?type=command&param=getSunRiseSet";
             String UPDATE = "/json.htm?type=command&param=checkforupdate&forced=true";
             String USERVARIABLES = "/json.htm?type=command&param=getuservariables";
-            String EVENTS = "/json.htm?type=events&param=list";
-            String EVENTS_UPDATE_STATUS = "/json.htm?type=events&param=updatestatus&eventid=";
+            String EVENTS = "/json.htm?type=command&param=getevents&evparam=list";
+            String EVENTS_UPDATE_STATUS = "/json.htm?type=command&param=getevents&evparam=updatestatus&eventid=";
             String RGBCOLOR = "/json.htm?type=command&param=setcolbrightnessvalue&idx=";
             String KELVIN = "/json.htm?type=command&param=setkelvinlevel&idx=";
             String FULLLIGHT = "/json.htm?param=fulllight&type=command&idx=";
             String NIGHTLIGHT = "/json.htm?param=nightlight&type=command&idx=";
-            String SETTINGS = "/json.htm?type=settings";
+            String SETTINGS = "/json.htm?type=command&param=getsettings";
             String CONFIG = "/json.htm?type=command&param=getconfig";
             String SETSECURITY = "/json.htm?type=command&param=setsecstatus";
             String UPDATE_DOWNLOAD_UPDATE = "/json.htm?type=command&param=downloadupdate";
@@ -528,8 +528,8 @@ public class DomoticzValues {
             String CLEAN_MOBILE_DEVICE = "/json.htm?type=command&param=deletemobiledevice";
             String LANGUAGE_TRANSLATIONS = "/i18n/domoticz-";
             String SEND_NOTIFICATION = "/json.htm?type=command&param=sendnotification";
-            String NOTIFICATIONTYPES = "/json.htm?type=notifications";
-            String USERS = "/json.htm?type=users";
+            String NOTIFICATIONTYPES = "/json.htm?type=command&param=getnotifications";
+            String USERS = "/json.htm?type=command&param=getusers";
             String AUTH = "/json.htm?type=command&param=getauth";
             String LOGOFF = "/json.htm?type=command&param=dologout";
             String LOG = "/json.htm?type=command&param=addlogmessage&message=";


### PR DESCRIPTION
Small (untested) PR that updates the API calls for domoticz to replace the deprecated RType calls (type=<somertype>)

@galadril , I am not able to actually test these changes (unable to build this project) so please verify them.

Most changed call will still be supported in the next stable, but will generate a '_deprecated_' status message.

(Only 'events' causes a problem as it uses the `param` parameter which had to change to `evparam` as 'param' is used by 'type=command')